### PR TITLE
Update unittests to new package name path.

### DIFF
--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -9,7 +9,7 @@ import json
 from typing import Dict
 from unittest import TestCase
 
-from json_object import JSONObject
+from python_easy_json import JSONObject
 
 
 class BaseTestCase(TestCase):

--- a/tests/test_data_export.py
+++ b/tests/test_data_export.py
@@ -5,7 +5,7 @@
 import json
 
 from tests.base_test import BaseTestCase
-from json_object import JSONObject
+from python_easy_json import JSONObject
 
 
 class TestDataExport(BaseTestCase):

--- a/tests/test_object_model.py
+++ b/tests/test_object_model.py
@@ -3,7 +3,7 @@
 # file 'LICENSE', which is part of this source code package.
 #
 from datetime import date, datetime
-from json_object import JSONObject
+from python_easy_json import JSONObject
 from tests.base_test import BaseTestCase
 from typing import List
 

--- a/tests/test_simple_json.py
+++ b/tests/test_simple_json.py
@@ -3,7 +3,7 @@
 # file 'LICENSE', which is part of this source code package.
 #
 from tests.base_test import BaseTestCase
-from json_object import JSONObject
+from python_easy_json import JSONObject
 
 
 class TestSimpleDict(BaseTestCase):


### PR DESCRIPTION
After finding a package name that is unique enough on PiPy, I forgot to update the unittest imports.  This fixes that so the unittests run again.