### PR TITLE
Fix issue where list of int or str causes error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__VERSION__ = "1.0.2"
+__VERSION__ = "1.0.4"
 
 base_dir = os.path.abspath(os.path.dirname(__file__))
 

--- a/src/python_easy_json/json_object.py
+++ b/src/python_easy_json/json_object.py
@@ -67,7 +67,7 @@ class JSONObject:
                         elif isinstance(i, str):
                             try:
                                 _tmp_data = json.loads(i)
-                                if _tmp_data:
+                                if _tmp_data and isinstance(_tmp_data, dict):
                                     _tmp.append(self._get_annot_cls(k)(_tmp_data, cast_types=cast_types,
                                                                        ordered=ordered))
                                 else:

--- a/tests/test_data/nested_lists.json
+++ b/tests/test_data/nested_lists.json
@@ -1,0 +1,22 @@
+{
+  "topping": [
+    {
+      "id": "5001",
+      "type": "None"
+    },
+    {
+      "id": "5002",
+      "type": "Glazed"
+    }
+  ],
+  "string_list": [
+    "abc",
+    "def",
+    "xyz"
+  ],
+  "integer_list": [
+    1,
+    2,
+    3
+  ]
+}

--- a/tests/test_json_with_lists.py
+++ b/tests/test_json_with_lists.py
@@ -1,0 +1,36 @@
+#
+# This file is subject to the terms and conditions defined in the
+# file 'LICENSE', which is part of this source code package.
+#
+from typing import List
+
+from tests.base_test import BaseTestCase
+from python_easy_json import JSONObject
+from tests.test_object_model import CakeToppingTypeModel
+
+
+class ListTestObject(JSONObject):
+
+    topping: List[CakeToppingTypeModel]
+    string_list: List[str]
+    integer_list: List[int]
+
+
+class TestListsDict(BaseTestCase):
+
+    def test_data_with_lists(self):
+        """ Test simple JSON, no type casting. """
+        obj = ListTestObject(self.json_data.nested_lists)
+
+        self.assertIsInstance(obj, ListTestObject)
+
+        for t in obj.topping:
+            self.assertIsInstance(t, CakeToppingTypeModel)
+
+        for s in obj.string_list:
+            self.assertIsInstance(s, str)
+            self.assertIn(s, ['abc', 'def', 'xyz'])
+
+        for i in obj.integer_list:
+            self.assertIsInstance(i, int)
+            self.assertIn(i, [1, 2, 3])


### PR DESCRIPTION
A nested list of string values would cause an error where the code to determine if there is a nested object would succeed when we make a call to 'json.loads()'.  This fix ensures we test the return value of 'json.loads()' to make sure we have a 'dict' object.