### PR TITLE
Support annotation casting to Enum class types

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__VERSION__ = "1.0.4"
+__VERSION__ = "1.0.5"
 
 base_dir = os.path.abspath(os.path.dirname(__file__))
 

--- a/src/python_easy_json/json_object.py
+++ b/src/python_easy_json/json_object.py
@@ -87,8 +87,14 @@ class JSONObject:
                             elif self.__annotations__[k] == datetime.datetime:
                                 self.__dict__[k] = dt_parser.parse(str(v))
                             else:
-                                self.__dict__[k] = self.__annotations__[k](str(v))
+                                try:
+                                    self.__dict__[k] = self.__annotations__[k](str(v))
+                                except ValueError:
+                                    # try original type in case annotation type is an Enum and value is an integer.
+                                    self.__dict__[k] = self.__annotations__[k](v)
                         except TypeError:
+                            pass
+                        except ValueError:
                             pass
 
         if _cleaned_data:

--- a/tests/test_json_with_enum.py
+++ b/tests/test_json_with_enum.py
@@ -1,0 +1,55 @@
+#
+# This file is subject to the terms and conditions defined in the
+# file 'LICENSE', which is part of this source code package.
+#
+from datetime import datetime
+from enum import Enum, IntEnum
+
+from tests.base_test import BaseTestCase
+from python_easy_json import JSONObject
+
+
+class TestEnum(Enum):
+
+    FirstValue = 1
+    SecondValue = 2
+
+
+class TestIntEnum(IntEnum):
+
+    FirstValue = 1
+    SecondValue = 2
+
+
+class ObjectWithEnum(JSONObject):
+    """ JSONObject object class with Enum types """
+    timestamp: datetime = None
+    test_enum: TestEnum = None
+    test_int_enum: TestIntEnum = None
+
+
+class TestJSONWithEnum(BaseTestCase):
+
+    def test_object_with_enum_values(self):
+        """ Test JSONObject class with IntEnum property. """
+        ts = datetime.utcnow()
+
+        data = {
+            'timestamp': ts.isoformat(),
+            'test_enum': TestEnum.FirstValue.value,
+            'test_int_enum': TestIntEnum.SecondValue.value
+        }
+
+        obj = ObjectWithEnum(data, cast_types=True)
+
+        self.assertIsInstance(obj, JSONObject)
+
+        self.assertEqual(obj.timestamp, ts)
+
+        # TestEnum
+        self.assertIsInstance(obj.test_enum, TestEnum)
+        self.assertEqual(obj.test_enum, TestEnum.FirstValue)
+
+        # TestIntEnum
+        self.assertIsInstance(obj.test_int_enum, TestIntEnum)
+        self.assertEqual(obj.test_int_enum, TestIntEnum.SecondValue)


### PR DESCRIPTION
* Support casting data value to Enum class if annotation is a class derived from a Python Enum class.
* Added unittest for testing enum class annotations.
* Bump version to v1.0.5.