### PR TITLE
Handle incomplete nested object annotations.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__VERSION__ = "1.0.5"
+__VERSION__ = "1.0.6"
 
 base_dir = os.path.abspath(os.path.dirname(__file__))
 

--- a/src/python_easy_json/json_object.py
+++ b/src/python_easy_json/json_object.py
@@ -30,7 +30,10 @@ class JSONObject:
             # See if this annotation is a list of objects, if so, get the first
             # available object type in the list.
             if hasattr(cls_, '_name') and cls_._name == 'List':
-                cls_ = cls_.__args__[0]
+                try:
+                    cls_ = cls_.__args__[0]
+                except AttributeError:
+                    pass
         return cls_
 
     def __init__(self, data: Union[Dict, str, None] = None, cast_types: bool = False, ordered: bool = False):
@@ -63,7 +66,10 @@ class JSONObject:
                     _tmp = list()
                     for i in v:
                         if isinstance(i, dict):
-                            _tmp.append(self._get_annot_cls(k)(i, cast_types=cast_types, ordered=ordered))
+                            try:
+                                _tmp.append(self._get_annot_cls(k)(i, cast_types=cast_types, ordered=ordered))
+                            except TypeError:
+                                _tmp.append(JSONObject(i, cast_types=cast_types, ordered=ordered))
                         elif isinstance(i, str):
                             try:
                                 _tmp_data = json.loads(i)

--- a/tests/test_object_model.py
+++ b/tests/test_object_model.py
@@ -42,6 +42,11 @@ class CakeModel(JSONObject):
     topping: List[CakeToppingTypeModel]
 
 
+class IncompleteCakeModel(CakeModel):
+    # Force topping to just be a plain list.
+    topping: List = None
+
+
 class TestObjectModel(BaseTestCase):
     """ Test using JSONObject for data models """
 
@@ -141,3 +146,16 @@ class TestObjectModel(BaseTestCase):
 
         self.assertEqual(len(obj.topping), 7)
         self.assertEqual(len(obj.batters.batter), 4)
+
+    def test_incomplete_cake_models(self):
+        """ Test an incomplete annotated CakeModel model, test incomplete annotations for nested objects. """
+        obj = IncompleteCakeModel(self.json_data.nested_data_1)
+
+        self.assertIsInstance(obj, IncompleteCakeModel)
+        self.assertIsInstance(obj.topping, list)
+        self.assertIsInstance(obj.topping[0], JSONObject)
+
+        # Check that types were *NOT* converted to the property annotation type, because the type annotations
+        # are missing in this case.
+        self.assertIsInstance(obj.topping[0].id, str)
+        self.assertEqual(obj.topping[0].id, "5001")


### PR DESCRIPTION
If annotation for nested objects is incomplete or otherwise incorrect, fallback to generic JSONObject object when processing dictionary data.