### PR TITLE
to_dict method should not auto convert date values to str.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__VERSION__ = "1.0.6"
+__VERSION__ = "1.0.8"
 
 base_dir = os.path.abspath(os.path.dirname(__file__))
 

--- a/src/python_easy_json/json_object.py
+++ b/src/python_easy_json/json_object.py
@@ -138,7 +138,7 @@ class JSONObject:
         for k, v in self._clean_data().items():
             if isinstance(v, JSONObject) and recursive is True:
                 data[k] = v.to_dict(recursive=recursive, dates_to_str=dates_to_str)
-            elif isinstance(v, (datetime.datetime, datetime.date)):
+            elif isinstance(v, (datetime.datetime, datetime.date)) and dates_to_str is True:
                 data[k] = self._json_serial(v)
             elif isinstance(v, list):
                 nl = list()

--- a/tests/test_object_model.py
+++ b/tests/test_object_model.py
@@ -3,6 +3,8 @@
 # file 'LICENSE', which is part of this source code package.
 #
 from datetime import date, datetime
+from dateutil import parser as du_parser
+import json
 from python_easy_json import JSONObject
 from tests.base_test import BaseTestCase
 from typing import List
@@ -159,3 +161,21 @@ class TestObjectModel(BaseTestCase):
         # are missing in this case.
         self.assertIsInstance(obj.topping[0].id, str)
         self.assertEqual(obj.topping[0].id, "5001")
+
+    def test_to_dict_datetime_conversion(self):
+        """ Test that when using the "to_dict()" method that datetime values are handled correctly. """
+
+        input = json.loads(self.json_data.simple)
+        input['field_date'] = du_parser.parse(input['field_date']).date()
+        input['field_datetime'] = du_parser.parse(input['field_datetime'])
+
+        obj = SimpleModel(input)
+
+        # Test that date and datetime values are not converted to string
+        data = obj.to_dict(dates_to_str=False)
+        self.assertIsInstance(data['field_date'], date)
+        self.assertIsInstance(data['field_datetime'], datetime)
+
+        data = obj.to_dict(dates_to_str=True)
+        self.assertIsInstance(data['field_date'], str)
+        self.assertIsInstance(data['field_datetime'], str)


### PR DESCRIPTION
The 'to_dict()' method was always converting date or datetime values to string.  Added check to make sure date or datetime values are not converted to string values when 'dates_to_str' argument is False.
