### PR TITLE
Fix default properties handling and allow Enum key names when 'cast_types' is true

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__VERSION__ = "1.0.10"
+__VERSION__ = "1.0.12"
 
 base_dir = os.path.abspath(os.path.dirname(__file__))
 

--- a/src/python_easy_json/json_object.py
+++ b/src/python_easy_json/json_object.py
@@ -4,6 +4,7 @@
 #
 import datetime
 import json
+import inspect
 
 from collections import OrderedDict
 from dateutil import parser as dt_parser
@@ -103,10 +104,12 @@ class JSONObject:
                             pass
 
         # Look for any properties that have a default value on the class, but were not in the 'data' argument.
-        if hasattr(self, '__annotations__'):
-            for k in list(self.__annotations__.keys()):
-                if k not in self.__dict__ and hasattr(self, k) and getattr(self, k) is not None:
-                    self.__dict__[k] = getattr(self, k)
+        members = dict(inspect.getmembers(self.__class__, lambda a: not inspect.isroutine(a)))
+        for k, v in members.items():
+            if k.startswith('_'):
+                continue
+            if k not in self.__dict__ and hasattr(self, k) and getattr(self, k) is not None:
+                self.__dict__[k] = v
 
         if _cleaned_data:
             self._clean_data()

--- a/src/python_easy_json/json_object.py
+++ b/src/python_easy_json/json_object.py
@@ -93,11 +93,16 @@ class JSONObject:
                             elif self.__annotations__[k] == datetime.datetime:
                                 self.__dict__[k] = dt_parser.parse(str(v))
                             else:
+                                # Try setting the Enum class by value
                                 try:
                                     self.__dict__[k] = self.__annotations__[k](str(v))
                                 except ValueError:
                                     # try original type in case annotation type is an Enum and value is an integer.
-                                    self.__dict__[k] = self.__annotations__[k](v)
+                                    try:
+                                        self.__dict__[k] = self.__annotations__[k](v)
+                                    except ValueError:
+                                        # Try setting the Enum value by Key instead of value
+                                        self.__dict__[k] = self.__annotations__[k][str(v)]
                         except TypeError:
                             pass
                         except ValueError:

--- a/tests/test_object_model_defaults.py
+++ b/tests/test_object_model_defaults.py
@@ -4,11 +4,11 @@
 #
 from datetime import date, datetime
 from enum import Enum, IntEnum
+
 from dateutil import parser as du_parser
-import json
+
 from python_easy_json import JSONObject
 from tests.base_test import BaseTestCase
-from typing import List
 
 
 class TestEnum(Enum):
@@ -128,3 +128,14 @@ class TestObjectModel(BaseTestCase):
 
         self.assertIn('field_int_enum_value', data)
         self.assertEqual(data['field_int_enum_value'], TestIntEnum.Steel)
+
+    def test_simple_model_enum_by_key(self):
+        """
+        Test that the enum property can be set by the Enum key instead of value, when cast_types is True.
+        """
+        # Instantiate the class with Enum property key names, instead of Enum values.
+        obj = SimpleDefaultsModel({'field_enum_value': 'Peach', 'field_int_enum_value': 'Lithium'}, cast_types=True)
+
+        self.assertIsInstance(obj, SimpleDefaultsModel)
+        self.assertEqual(obj.field_enum_value, TestEnum.Peach)
+        self.assertEqual(obj.field_int_enum_value, TestIntEnum.Lithium)


### PR DESCRIPTION
* Improve handle default properties by inspecting the class object
* When 'cast_types' is true, allow setting an Enum property value by Enum key name.
* Added unittests to test setting property by Enum key name.