### PR TITLE
Fix for Union and Optional type hints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__VERSION__ = "1.0.14"
+__VERSION__ = "1.0.16"
 
 base_dir = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
When a subclass of JSONObject has a property with 'typing.Union' or 'typing.Optional' type hint that include other JSONObjects we need to try and find the correct class type in the list of possible annotation types for the property.