### PR TITLE
Better handle casting annotations when value is None

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__VERSION__ = "1.1.0"
+__VERSION__ = "1.1.2"
 
 base_dir = os.path.abspath(os.path.dirname(__file__))
 

--- a/src/python_easy_json/json_object.py
+++ b/src/python_easy_json/json_object.py
@@ -119,7 +119,7 @@ class JSONObject:
                 else:
                     self.__dict__[k] = v
                     # Try to cast values to annotation type if type annotation have been set.
-                    if cast_types is True and k in annots:
+                    if v and cast_types is True and k in annots:
                         try:
                             if annots[k] == datetime.date:
                                 self.__dict__[k] = dt_parser.parse(str(v)).date()

--- a/tests/test_object_model.py
+++ b/tests/test_object_model.py
@@ -250,3 +250,25 @@ class TestObjectModel(BaseTestCase):
         # Test JSONObject class
         self.assertEqual(obj.settings.temp, 250.0)
         self.assertEqual(obj.settings.time, 45.0)
+
+    def test_null_values_for_annotated_class(self):
+        """ Pass None for values to annotated class """
+
+        input_ = {
+            'field_bool': None,
+            'field_int': None,
+            'field_float': None,
+            'field_str': None,
+            'field_date': None,
+            'field_datetime':  None
+        }
+
+        obj = SimpleModel(input_, cast_types=True)
+        self.assertIsInstance(obj, SimpleModel)
+
+        self.assertIsNone(obj.field_bool)
+        self.assertIsNone(obj.field_int)
+        self.assertIsNone(obj.field_float)
+        self.assertIsNone(obj.field_str)
+        self.assertIsNone(obj.field_date)
+        self.assertIsNone(obj.field_datetime)


### PR DESCRIPTION
With recent changes, casting to date and datetime types causes an exception.  Test for None value before trying to cast values to annotation types.