### PR TITLE
Code clean up, ensure data keys with hyphens work correctly.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__VERSION__ = "1.1.4"
+__VERSION__ = "1.1.6"
 
 base_dir = os.path.abspath(os.path.dirname(__file__))
 

--- a/tests/test_json_with_dicts.py
+++ b/tests/test_json_with_dicts.py
@@ -59,3 +59,20 @@ class TestListsDict(BaseTestCase):
 
         for v in obj.test_prop:
             self.assertIsInstance(v, JSONObject)
+
+    def test_nested_dict_with_hyphen_key(self):
+        """
+        Test a key with a hyphen containing a nested dictionary.  Any key with a hyphen should have the hyphen
+        converted to an underscore.
+        """
+        data = {
+            'z-report': {
+                'zap-col1': 'abc',
+                'zap-col2': 'xyz'
+            }
+        }
+        obj = JSONObject(data)
+
+        self.assertIsInstance(obj, JSONObject)
+        self.assertTrue(hasattr(obj, 'z_report'))
+        self.assertEqual(obj.z_report.zap_col1, 'abc')


### PR DESCRIPTION
* Fixes dictionary keys with nested data and a hyphen in the key that cause a key lookup error. 
* Code cleanup and pre-test for Python <= 3.6.
* Ensure we use the correct dictionary class type through out the code when instantiating new dict objects.