### PR TITLE
Check that property values are set correctly after init

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__VERSION__ = "1.1.6"
+__VERSION__ = "1.1.7"
 
 base_dir = os.path.abspath(os.path.dirname(__file__))
 

--- a/src/python_easy_json/json_object.py
+++ b/src/python_easy_json/json_object.py
@@ -22,6 +22,7 @@ class JSONObject:
     """
     Simple object to recursively convert a dict or json string to object properties
     """
+    __initialized__ = False
     @staticmethod
     def _get_annot_cls(annots: dict, key: str, ignore_builtins = False) -> typing.List:
         """
@@ -165,6 +166,7 @@ class JSONObject:
                 for k, v in cleaned_data.items():
                     self.__dict__[k] = v
                 self.__data_dict__ = cleaned_data
+            self.__initialized__ = True
             return
 
         if annots:
@@ -213,6 +215,13 @@ class JSONObject:
         for k, v in cleaned_data.items():
             self.__dict__[k] = v
         self.__data_dict__ = cleaned_data
+        __initialized__ = True
+
+    def __setattr__(self, key, value):
+        super().__setattr__(key, value)
+        if not self.__initialized__ or key.startswith('__'):
+            return
+        self.__data_dict__[key] = value
 
     @staticmethod
     def _json_serial(obj):

--- a/tests/test_simple_json.py
+++ b/tests/test_simple_json.py
@@ -55,3 +55,57 @@ class TestSimpleDict(BaseTestCase):
         self.assertEqual(obj.field_list[1], 'null')
         self.assertIsNone(obj.field_list[2])
 
+    def test_property_set_after_init(self):
+        """ Test additional property setting is recorded after the object is initialized """
+        obj = JSONObject({'prop_abc': None})
+
+        self.assertIsInstance(obj, JSONObject)
+
+        self.assertIsNone(obj.prop_abc)
+        data = obj.to_dict()
+        self.assertIsNone(data['prop_abc'])
+
+        obj.prop_abc = '123'
+
+        self.assertEqual(obj.prop_abc, '123')
+        data = obj.to_dict()
+        self.assertEqual(data['prop_abc'], '123')
+
+    def test_setting_object_after_init(self):
+        """ Test setting a nested object after init """
+
+        obj = JSONObject({'prop_obj': None})
+
+        nested_obj = JSONObject({'nested_prop': 123})
+
+        self.assertIsInstance(obj, JSONObject)
+        self.assertIsInstance(nested_obj, JSONObject)
+
+        obj.prop_obj = nested_obj
+
+        data = obj.to_dict()
+        self.assertIsInstance(data['prop_obj'], dict)
+        self.assertEqual(data['prop_obj']['nested_prop'], 123)
+
+    def test_property_with_single_hyphen(self):
+
+        obj = JSONObject({'_test_prop': 123})
+
+        self.assertIsInstance(obj, JSONObject)
+        self.assertEqual(obj._test_prop, 123)
+
+        data = obj.to_dict()
+        self.assertEqual(data['_test_prop'], 123)
+
+    def test_setattr_after_init(self):
+        """ Test that calling setattr() works correctly after init """
+
+        obj = JSONObject({'test_prop': 123})
+        self.assertIsInstance(obj, JSONObject)
+
+        setattr(obj, 'new_prop', 'abc')
+        self.assertEqual(obj.new_prop, 'abc')
+
+        data = obj.to_dict()
+        self.assertEqual(data['new_prop'], 'abc')
+        self.assertEqual(data['test_prop'], 123)


### PR DESCRIPTION
After a JSONObject has been created, ensure that updates to the property values are being recorded correctly.

Ensure that property names that begin with a single underscore are handled correctly.