### PR TITLE
Ensure un-castable values don't fail

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__VERSION__ = "1.1.8"
+__VERSION__ = "1.1.9"
 
 base_dir = os.path.abspath(os.path.dirname(__file__))
 

--- a/src/python_easy_json/json_object.py
+++ b/src/python_easy_json/json_object.py
@@ -106,9 +106,8 @@ class JSONObject:
         # Support Unions types which may have multiple types defined.
         annot_types = cls._get_annot_cls(annots, k)
         # Check to see if the value is already in the correct type.
-        for t in annot_types:
-            if type(v) == t:
-                return v
+        if type(v) in annot_types:
+            return v
 
         for t in annot_types:
             if t == datetime.date and not isinstance(v, datetime.date):
@@ -133,8 +132,11 @@ class JSONObject:
                         v = t[str(v)]
                         break
             else:
-                v = t(v)
-                break
+                try:
+                    v = t(v)
+                    break
+                except (TypeError, ValueError):
+                    pass
 
         return v
 

--- a/tests/test_object_model.py
+++ b/tests/test_object_model.py
@@ -56,6 +56,10 @@ class PythonTypingUnionModel(JSONObject):
     settings: Optional[JSONObject] = None
 
 
+class UnCastableTypingUnionModel(JSONObject):
+    data: Union[bytes, int] = None
+
+
 class TestObjectModel(BaseTestCase):
     """ Test using JSONObject for data models """
 
@@ -272,3 +276,16 @@ class TestObjectModel(BaseTestCase):
         self.assertIsNone(obj.field_str)
         self.assertIsNone(obj.field_date)
         self.assertIsNone(obj.field_datetime)
+
+
+    def test_uncastable_annotation_value(self):
+        """ Attempt to cast an un-castable value for a union annotation """
+
+        data = {'data': 'this is a string'}
+
+        obj = UnCastableTypingUnionModel(data, cast_types=True)
+
+        self.assertIsInstance(obj, UnCastableTypingUnionModel)
+
+        self.assertIsInstance(obj.data, str)
+        self.assertEqual('this is a string', obj.data)


### PR DESCRIPTION
If a value is passed that cannot be cast as an annotation type, handle it gracefully.